### PR TITLE
Paths_servant_polysemy has no business of being exposed from the library

### DIFF
--- a/servant-polysemy.cabal
+++ b/servant-polysemy.cabal
@@ -64,12 +64,12 @@ library
   default-language:    Haskell2010
   exposed-modules:     Servant.Polysemy.Client
                        Servant.Polysemy.Server
-                       Paths_servant_polysemy
-  autogen-modules:     Paths_servant_polysemy
 
 executable example-server
   import:            deps
   main-is:             Server.hs
+  autogen-modules:     Paths_servant_polysemy
+  other-modules:       Paths_servant_polysemy
   hs-source-dirs:      example
   default-language:    Haskell2010
   ghc-options:       -threaded
@@ -81,6 +81,8 @@ executable example-server
 executable example-server-with-swagger
   import:            deps
   main-is:             ServerWithSwagger.hs
+  autogen-modules:     Paths_servant_polysemy
+  other-modules:       Paths_servant_polysemy
   hs-source-dirs:      example
   default-language:    Haskell2010
   ghc-options:       -threaded


### PR DESCRIPTION
Basically, this. Otherwise this module gets an entry in Haddock, which it probably shouldn't.