### PR TITLE
Exterimental auth

### DIFF
--- a/example/AuthServer.hs
+++ b/example/AuthServer.hs
@@ -1,0 +1,79 @@
+-- | This is the example of how to use generalised authentication from Servant
+--   with Polysemy in mind.
+--   See here for more info: https://docs.servant.dev/en/stable/tutorial/Authentication.html
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings#-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+module Main (main) where
+
+import Data.Version (Version, showVersion)
+import Network.Wai
+import Paths_servant_polysemy as Paths
+import Polysemy
+import Polysemy.Error
+import Servant
+import Servant.API.Generic (ToServantApi, (:-), Generic)
+import Servant.Polysemy.Server
+import Servant.Polysemy.Server.Auth
+import Servant.Server.Experimental.Auth
+import Servant.Server.Generic (AsServerT)
+
+newtype Token = Token String
+
+type TokenProtect = AuthProtect "token"
+
+type instance AuthServerData TokenProtect = Token
+
+-- This example is of the same server as defined in Server.hs, but it uses Servant.API.Generic to define the path.
+
+-- This is the Servant.API.Generic style  of creating an API.
+data Routes route = Routes
+  { _version :: route :- "api" :> "v1" :> "version" :> Get '[JSON] Version
+  , _secret :: route :- TokenProtect :> "api" :> "v1" :> "secret" :> Get '[JSON] String
+  } deriving (Generic)
+
+type MyApi = ToServantApi Routes
+
+-- This is the endpoint, which responds to a GET at /api/v1/version with the server's version in JSON format.
+handleVersion :: Member (Embed IO) r => Sem r Version
+handleVersion = do
+  embed $ putStrLn $ "Returning version " <> showVersion Paths.version
+  pure Paths.version
+
+-- This is the endpoint, which requires authentication to access.
+handleSecret :: Member (Embed IO) r => Token -> Sem r String
+handleSecret (Token tok) = do
+  embed $ putStrLn $ "Supplied with token " <> tok
+  return "Ok"
+
+routes :: Member (Embed IO) r => Routes (AsServerT (Sem (Error ServerError ': r)))
+routes = Routes
+  { _version = handleVersion
+  , _secret = handleSecret
+  }
+
+authHandler :: Members '[Embed IO, Error ServerError] r
+            => Request -> Sem r Token
+authHandler req = case token of
+                    Nothing -> embed (putStrLn "Authentication failed: no token provided") >> throw401 "No token provided"
+                    Just t | t == "magictoken" -> Token "magictoken" <$ embed (putStrLn "Authentication successful")
+                           | otherwise -> embed (putStrLn "Authentication failed: token invalid") >> throw401 "Invalid token"
+  where throw401 msg = throw (ServerError 401 msg mempty [])
+        token = lookup "X-Token" $ requestHeaders req
+
+myServer :: Member (Embed IO) r => ServerT MyApi (Sem (Error ServerError ': r))
+myServer = toServant routes
+
+-- This runs Warp (a Haskell web server), serving up our API.
+main :: IO ()
+main = runM
+     $ withAuthHandler authHandler $ \ahdl ->
+       let ctx :: Context (AuthHandler Request Token ': '[])
+           ctx = ahdl :. EmptyContext
+       in runWarpServerCtx @MyApi 8080 True ctx myServer
+
+

--- a/example/ServerMiddleware.hs
+++ b/example/ServerMiddleware.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+module Main (main) where
+
+import Data.Version (Version, showVersion)
+import Paths_servant_polysemy as Paths
+import Network.Wai (mapResponseHeaders)
+import Network.Wai.Handler.Warp
+import Polysemy
+import Polysemy.Error
+import Servant
+import Servant.Polysemy.Server
+
+{-
+This is a very simple server with only one endpoint.
+-}
+
+-- This is the endpoint, which responds to a GET at /api/v1/version with the server's version in JSON format.
+type MyApi = "api" :> "v1" :> "version" :> Get '[JSON] Version
+
+-- This is the implementation of the API.
+-- It also does some IO to print to the terminal.
+myServer :: Member (Embed IO) r => ServerT MyApi (Sem (Error ServerError ': r))
+myServer = do
+  embed $ putStrLn $ "Returning version " <> showVersion Paths.version
+  pure Paths.version
+
+addHeader1 :: Application -> Application
+addHeader1 app request resp = app request (resp . mapResponseHeaders (hdr:))
+  where hdr = ("Header1", "DERP")
+
+addHeader2 :: Middleware r
+addHeader2 = Middleware $ \app req resp -> app req (resp . mapResponseHeaders (hdr:))
+  where hdr = ("Header2", "HERP")
+
+-- This runs Warp (a Haskell web server), serving up our API.
+main :: IO ()
+main = runM
+     $ runWarpServerEx @MyApi s myServer
+  where s = defaultServerSettings { waiMiddleware = [addHeader1]
+                                  , middleware = [addHeader2]
+                                  , warpSettings = setPort 8080
+                                                 $ setOnExceptionResponse exceptionResponseForDebug
+                                                 $ defaultSettings
+                                  }
+

--- a/servant-polysemy.cabal
+++ b/servant-polysemy.cabal
@@ -80,6 +80,19 @@ executable example-server
   build-depends:       servant-polysemy
                      , lens
 
+executable example-server-middleware
+  import:            deps
+  main-is:             ServerMiddleware.hs
+  autogen-modules:     Paths_servant_polysemy
+  other-modules:       Paths_servant_polysemy
+  hs-source-dirs:      example
+  default-language:    Haskell2010
+  ghc-options:       -threaded
+                     -rtsopts
+                     -with-rtsopts=-N
+  build-depends:       servant-polysemy
+
+
 executable example-server-generic
   import:            deps
   main-is:             ServerGeneric.hs

--- a/servant-polysemy.cabal
+++ b/servant-polysemy.cabal
@@ -29,7 +29,7 @@ common deps
                      , http-client      >= 0.6.4.1 && < 0.8
                      , http-client-tls ^>= 0.3.5.3
                      , mtl             ^>= 2.2.2
-                     , polysemy         >= 1.3.0.0 && < 1.9
+                     , polysemy         >= 1.3.0.0 && < 2.0
                      , polysemy-plugin  >= 0.2.4.0 && < 0.5
                      , polysemy-zoo     >= 0.7.0.1 && < 0.9
                      , servant-server   >= 0.16 && < 0.20

--- a/servant-polysemy.cabal
+++ b/servant-polysemy.cabal
@@ -65,6 +65,7 @@ library
   default-language:    Haskell2010
   exposed-modules:     Servant.Polysemy.Client
                        Servant.Polysemy.Server
+                       Servant.Polysemy.Server.Auth
 
 executable example-server
   import:            deps
@@ -93,6 +94,19 @@ executable example-server-generic
                      , lens
                      , servant
 
+executable example-server-generic-auth
+  import:            deps
+  main-is:             AuthServer.hs
+  autogen-modules:     Paths_servant_polysemy
+  other-modules:       Paths_servant_polysemy
+  hs-source-dirs:      example
+  default-language:    Haskell2010
+  ghc-options:       -threaded
+                     -rtsopts
+                     -with-rtsopts=-N
+  build-depends:       servant-polysemy
+                     , servant
+
 executable example-server-with-swagger
   import:            deps
   main-is:             ServerWithSwagger.hs
@@ -119,6 +133,8 @@ executable example-client
                      -rtsopts
                      -with-rtsopts=-N
   build-depends:       servant-polysemy
+
+
 
 source-repository head
   type:     git

--- a/servant-polysemy.cabal
+++ b/servant-polysemy.cabal
@@ -29,7 +29,7 @@ common deps
                      , http-client      >= 0.6.4.1 && < 0.8
                      , http-client-tls ^>= 0.3.5.3
                      , mtl             ^>= 2.2.2
-                     , polysemy         >= 1.3.0.0 && < 1.8
+                     , polysemy         >= 1.3.0.0 && < 1.9
                      , polysemy-plugin  >= 0.2.4.0 && < 0.5
                      , polysemy-zoo     >= 0.7.0.1 && < 0.9
                      , servant-server   >= 0.16 && < 0.20

--- a/servant-polysemy.cabal
+++ b/servant-polysemy.cabal
@@ -135,7 +135,7 @@ executable example-server-with-swagger
                      , servant-swagger    ^>= 1.1
                      , servant-swagger-ui ^>= 0.3
                      , swagger2            >= 2.4 && < 2.9
-                     , text               ^>= 1.2.3.1
+                     , text                >= 1.2.3.1 && < 3.0
 
 executable example-client
   import:            deps

--- a/src/Servant/Polysemy/Server/Auth.hs
+++ b/src/Servant/Polysemy/Server/Auth.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeOperators #-}
-module Servant.Polysemy.Server.Auth (mkAuthHandlerSem, withAuthHandler) where
+module Servant.Polysemy.Server.Auth (withAuthHandler) where
 
 import Servant.Polysemy.Server
 
@@ -10,14 +10,6 @@ import Polysemy
 import Polysemy.Error
 import Servant.Server.Experimental.Auth
 import Servant (ServerError)
-
--- | Create an authentication handler from a supplied effectful function.
---   The first argument is supposed to be obtained from 'withLowerToIO'.
---   This is a low-level function and you probably shouldn't use it, unless
---   you're absolutely sure of what you're doing. For a more user-friendly version
---   see 'withAuthHandler'.
-mkAuthHandlerSem :: (forall x. Sem r x -> IO x) -> (auth -> Sem (Error ServerError ': r) usr) -> AuthHandler auth usr
-mkAuthHandlerSem lowerToIO hdl = mkAuthHandler (semHandler lowerToIO . hdl)
 
 -- | Create an authentication handler and submit it to a callback function.
 --   'withAuthHandler' uses 'withLowerToIO' under the hood, so all limitations
@@ -43,6 +35,4 @@ withAuthHandler :: Member (Embed IO) r
                 => (auth -> Sem (Error ServerError ': r) usr)
                 -> (AuthHandler auth usr -> Sem r a)
                 -> Sem r a
-withAuthHandler f g = withLowerToIO $ \lowerToIO finish ->
-  let hdl = mkAuthHandlerSem lowerToIO f
-  in lowerToIO (g hdl) <* finish
+withAuthHandler = withHandler mkAuthHandler

--- a/src/Servant/Polysemy/Server/Auth.hs
+++ b/src/Servant/Polysemy/Server/Auth.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeOperators #-}
+module Servant.Polysemy.Server.Auth (mkAuthHandlerSem, withAuthHandler) where
+
+import Servant.Polysemy.Server
+
+import Polysemy
+import Polysemy.Error
+import Servant.Server.Experimental.Auth
+import Servant (ServerError)
+
+-- | Create an authentication handler from a supplied effectful function.
+--   The first argument is supposed to be obtained from 'withLowerToIO'.
+--   This is a low-level function and you probably shouldn't use it, unless
+--   you're absolutely sure of what you're doing. For a more user-friendly version
+--   see 'withAuthHandler'.
+mkAuthHandlerSem :: (forall x. Sem r x -> IO x) -> (auth -> Sem (Error ServerError ': r) usr) -> AuthHandler auth usr
+mkAuthHandlerSem lowerToIO hdl = mkAuthHandler (semHandler lowerToIO . hdl)
+
+-- | Create an authentication handler and submit it to a callback function.
+--   'withAuthHandler' uses 'withLowerToIO' under the hood, so all limitations
+--   of that function are present here. Notably, you should compile your code with
+--   "-threaded" GHC flag.
+--   Use example:
+--   @
+--     authHandler :: Members '[Embed IO, Error ServerError] r
+--                 => Request -> Sem r Token
+--     authHandler req = <...>  -- Validate the request and extract the token
+--
+--     main :: IO ()
+--     main = runM
+--          $ withAuthHandler authHandler $ \ahdl ->
+--            let ctx :: Context (AuthHandler Request Token ': '[])
+--                ctx = ahdl :. EmptyContext
+--            in runWarpServerCtx @MyApi 8080 True ctx myServer
+--    @
+--    See servant documentation here for more details: https://docs.servant.dev/en/stable/tutorial/Authentication.html
+--    Also, see the example in 'examples/AuthServer.hs'.
+
+withAuthHandler :: Member (Embed IO) r
+                => (auth -> Sem (Error ServerError ': r) usr)
+                -> (AuthHandler auth usr -> Sem r a)
+                -> Sem r a
+withAuthHandler f g = withLowerToIO $ \lowerToIO finish ->
+  let hdl = mkAuthHandlerSem lowerToIO f
+  in lowerToIO (g hdl) <* finish


### PR DESCRIPTION
Introduce context-aware versions of 'runWarpServer*' functions and implement generalised authentication support via an `AuthHandler`.

For more details, see here: https://hackage.haskell.org/package/servant-server-0.19.2/docs/Servant-Server-Experimental-Auth.html
And here: https://docs.servant.dev/en/stable/tutorial/Authentication.html